### PR TITLE
flatbuffers: Import v1.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.4)
 
 project(KodiDependencies LANGUAGES C)
 
@@ -59,10 +59,12 @@ function(add_dependency_project_package name version)
 	# it's possible to pack dependency only if it was installed in separate folder
 	if(FOLDER_PER_TARGET)
 		set(dep_name "${name}-${version}")
-		if(CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-			set(dep_name "${dep_name}-win10")
+		if(NOT ANY IN_LIST ARGN)
+			if(CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+				set(dep_name "${dep_name}-win10")
+			endif()
+			set(dep_name "${dep_name}-$(Platform)-$(PlatformToolset)")
 		endif()
-		set(dep_name "${dep_name}-$(Platform)-$(PlatformToolset)")
 		file(TO_NATIVE_PATH "${PREFIX}/${dep_name}" COPY_DESTINATION)
 
 		ExternalProject_Add_StepTargets(${name} zip)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,24 @@ function(add_dependency_project_package name version)
 endfunction()
 
 
+# Executables for build
+
+ExternalProject_Add(flatc
+	DOWNLOAD_NAME flatbuffers-1.9.0.tar.gz
+	DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
+	URL https://github.com/google/flatbuffers/archive/v1.9.0.tar.gz
+	URL_HASH SHA256=5ca5491e4260cacae30f1a5786d109230db3f3a6e5a0eb45d0d0608293d247e3
+	PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
+	CMAKE_ARGS
+		${ADDITIONAL_ARGS}
+		-DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
+		-DFLATBUFFERS_BUILD_FLATHASH:BOOL=OFF
+		-DFLATBUFFERS_BUILD_FLATLIB:BOOL=OFF
+		-DFLATBUFFERS_BUILD_TESTS:BOOL=OFF
+)
+add_dependency_project_package(flatc 1.9.0)
+
+
 # dependencies required by others
 
 ExternalProject_Add(bzip2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,21 @@ ExternalProject_Add(easyhook
 add_dependency_project_package(easyhook 2.7.6035.0)
 endif()
 
+ExternalProject_Add(flatbuffers
+	DOWNLOAD_NAME flatbuffers-1.9.0.tar.gz
+	DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
+	URL https://github.com/google/flatbuffers/archive/v1.9.0.tar.gz
+	URL_HASH SHA256=5ca5491e4260cacae30f1a5786d109230db3f3a6e5a0eb45d0d0608293d247e3
+	CMAKE_ARGS
+		${ADDITIONAL_ARGS}
+		-DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
+		-DFLATBUFFERS_BUILD_FLATC:BOOL=OFF
+		-DFLATBUFFERS_BUILD_FLATHASH:BOOL=OFF
+		-DFLATBUFFERS_BUILD_FLATLIB:BOOL=OFF
+		-DFLATBUFFERS_BUILD_TESTS:BOOL=OFF
+)
+add_dependency_project_package(flatbuffers 1.9.0 ANY)
+
 ExternalProject_Add(fmt
 	DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
 	URL https://github.com/fmtlib/fmt/releases/download/3.0.1/fmt-3.0.1.zip
@@ -339,6 +354,7 @@ add_custom_target(DependenciesRequired
 	DEPENDS
 		crossguid
 		easyhook
+		flatbuffers
 		fmt
 		freetype
 		libcdio

--- a/patches/flatc.diff
+++ b/patches/flatc.diff
@@ -1,0 +1,19 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -257,8 +257,6 @@
+ if(FLATBUFFERS_INSTALL)
+   include(GNUInstallDirs)
+ 
+-  install(DIRECTORY include/flatbuffers DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+-
+   set(FB_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/flatbuffers")
+ 
+   configure_file(CMake/FlatbuffersConfigVersion.cmake.in FlatbuffersConfigVersion.cmake @ONLY)
+@@ -292,7 +290,6 @@ if(FLATBUFFERS_INSTALL)
+     install(
+       TARGETS flatc EXPORT FlatcTargets
+       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+-      CONFIGURATIONS Release
+     )
+ 
+     install(


### PR DESCRIPTION
Note that for Debug builds, this produces no `flatc.exe`. I tried to override with the `-DCMAKE_BUILD_TYPE=Release` line, which doesn't work, but do we ever need to build this repo as Debug anyways?