### PR TITLE
Reenable arm builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        arch: [win32, x64, arm64]
+        arch: [win32, x64, arm, arm64]
         platform: [-App, -Desktop]
         exclude:
           - arch: arm

--- a/BuildAllPlatforms.ps1
+++ b/BuildAllPlatforms.ps1
@@ -76,7 +76,7 @@ Param(
   [switch] $Desktop = $false,
   [switch] $App = $false,
   [ValidateSet( 'arm', 'win32', 'x64', 'arm64' )]
-  [string[]] $Platforms = @( 'win32', 'x64', 'arm64' ),
+  [string[]] $Platforms = @( 'arm', 'win32', 'x64', 'arm64' ),
   [ValidateSet('10.0.17763.0', '10.0.18362.0')]
   [string] $SdkVersion = '10.0.18362.0',
   [ValidateSet(15, 16)]

--- a/DoRelease.ps1
+++ b/DoRelease.ps1
@@ -4,7 +4,7 @@ Param(
   [switch] $App,
   [switch] $NoClean,
   [ValidateSet( 'arm', 'win32', 'x64', 'arm64' )]
-  [string[]] $Platforms = @( 'win32', 'x64', 'arm64'),
+  [string[]] $Platforms = @( 'arm', 'win32', 'x64', 'arm64'),
   [ValidateSet('10.0.17763.0', '10.0.18362.0')]
   [string] $SdkVersion = '10.0.18362.0',
   [ValidateSet(15, 16)]


### PR DESCRIPTION
This was disabled when adding the date library, not sure if intentional. Trying to reenable again to check if it builds since we still need arm builds in our mirrors afaics