### PR TITLE
Bump Python to 3.8.15 and OpenSSL to 1.1.1q

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        arch: [win32, x64, arm, arm64]
+        arch: [win32, x64, arm]
         platform: [-App, -Desktop]
         exclude:
           - arch: arm

--- a/BuildAllPlatforms.ps1
+++ b/BuildAllPlatforms.ps1
@@ -75,8 +75,8 @@ Param(
   [switch] $Rebuild = $false,
   [switch] $Desktop = $false,
   [switch] $App = $false,
-  [ValidateSet( 'arm', 'win32', 'x64', 'arm64' )]
-  [string[]] $Platforms = @( 'arm', 'win32', 'x64', 'arm64' ),
+  [ValidateSet( 'arm', 'win32', 'x64' )]
+  [string[]] $Platforms = @( 'arm', 'win32', 'x64' ),
   [ValidateSet('10.0.17763.0', '10.0.18362.0')]
   [string] $SdkVersion = '10.0.18362.0',
   [ValidateSet(15, 16)]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,8 +144,8 @@ add_dependency_project_package(bzip2 1.0.8)
 
 ExternalProject_Add(expat
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
-    URL https://github.com/libexpat/libexpat/archive/R_2_2_9.tar.gz
-    URL_HASH SHA256=c341ac8c79e021cc3392a6d76e138e62d1dd287592cb455148540331756a2208
+    URL https://github.com/libexpat/libexpat/archive/R_2_4_9.tar.gz
+    URL_HASH SHA256=286bb78d8800f20b5da0ff48d98d6c67a16242cfe8cc823a04998f94b5253279
     PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     UPDATE_DISCONNECTED ON
     CMAKE_ARGS
@@ -158,7 +158,7 @@ ExternalProject_Add(expat
         -DEXPAT_SHARED_LIBS:BOOL=OFF
   SOURCE_SUBDIR expat
 )
-add_dependency_project_package(expat 2.2.9)
+add_dependency_project_package(expat 2.4.9)
 
 ExternalProject_Add(libiconv
     GIT_REPOSITORY https://github.com/Paxxi/libiconv
@@ -174,14 +174,14 @@ add_dependency_project_package(libiconv 1.16)
 
 ExternalProject_Add(openssl
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
-    URL https://www.openssl.org/source/openssl-1.1.1d.tar.gz
-    URL_HASH SHA256=1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2
+    URL https://www.openssl.org/source/openssl-1.1.1q.tar.gz
+    URL_HASH SHA256=d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca
     PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
 )
-add_dependency_project_package(openssl 1.1.1d)
+add_dependency_project_package(openssl 1.1.1q)
 
 ExternalProject_Add(zlib
     GIT_REPOSITORY https://github.com/Paxxi/zlib
@@ -750,15 +750,15 @@ add_dependency_project_package(libffi 3.3.0)
 
 ExternalProject_Add(python
     DEPENDS bzip2 openssl sqlite zlib expat libffi xz
-    GIT_REPOSITORY https://github.com/Paxxi/cpython
-    GIT_TAG 4cb8ef7c162e253c88fa584b27f30e33a8b67a18
+    GIT_REPOSITORY https://github.com/thexai/cpython
+    GIT_TAG ff25115e850caf01749c03e747f3b436b279775a
     GIT_SHALLOW ON
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
         -DCMAKE_PREFIX_PATH:PATH=${PREFIX}%3B%3B${PREFIX}/bzip2%3B%3B${PREFIX}/openssl%3B%3B${PREFIX}/sqlite%3B%3B${PREFIX}/zlib%3B%3B${PREFIX}/libffi%3B%3B${PREFIX}/xz%3B%3B${PREFIX}/expat
 )
-add_dependency_project_package(python 3.8.8)
+add_dependency_project_package(python 3.8.15)
 
 ExternalProject_Add(libjpeg-turbo
     GIT_REPOSITORY https://github.com/Paxxi/libjpeg-turbo

--- a/DoRelease.ps1
+++ b/DoRelease.ps1
@@ -3,8 +3,8 @@ Param(
   [switch] $Desktop,
   [switch] $App,
   [switch] $NoClean,
-  [ValidateSet( 'arm', 'win32', 'x64', 'arm64' )]
-  [string[]] $Platforms = @( 'arm', 'win32', 'x64', 'arm64'),
+  [ValidateSet( 'arm', 'win32', 'x64' )]
+  [string[]] $Platforms = @( 'arm', 'win32', 'x64' ),
   [ValidateSet('10.0.17763.0', '10.0.18362.0')]
   [string] $SdkVersion = '10.0.18362.0',
   [ValidateSet(15, 16)]

--- a/patches/expat.diff
+++ b/patches/expat.diff
@@ -2,8 +2,8 @@
 index 3417b69..7925ba1 100644
 --- a/expat/CMakeLists.txt
 +++ b/expat/CMakeLists.txt
-@@ -304,7 +304,8 @@ endif(NOT WIN32)
- expat_install(TARGETS ${_EXPAT_TARGET} EXPORT expat
+@@ -490,7 +490,8 @@ endif(NOT WIN32)
+ expat_install(TARGETS expat EXPORT expat
                        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 -                      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -12,7 +12,7 @@ index 3417b69..7925ba1 100644
  
  expat_install(FILES lib/expat.h lib/expat_external.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  
-@@ -530,13 +531,13 @@ expat_install(
+@@ -807,13 +807,13 @@ expat_install(
          ${CMAKE_CURRENT_BINARY_DIR}/cmake/expat-config.cmake
          ${CMAKE_CURRENT_BINARY_DIR}/cmake/expat-config-version.cmake
      DESTINATION

--- a/patches/openssl.diff
+++ b/patches/openssl.diff
@@ -115,7 +115,7 @@ diff --git a/Configurations/10-main.conf b/Configurations/10-main.conf
 index 3c4299d264..c5915a8561 100644
 --- a/Configurations/10-main.conf
 +++ b/Configurations/10-main.conf
-@@ -1287,7 +1287,7 @@ my %targets = (
+@@ -1309,7 +1309,7 @@ my %targets = (
      },
      "VC-WIN64I" => {
          inherit_from     => [ "VC-WIN64-common", asm("ia64_asm"),
@@ -124,7 +124,7 @@ index 3c4299d264..c5915a8561 100644
          AS               => "ias",
          ASFLAGS          => "-d debug",
          asoutflag        => "-o ",
-@@ -1299,7 +1299,7 @@ my %targets = (
+@@ -1321,7 +1321,7 @@ my %targets = (
      },
      "VC-WIN64A" => {
          inherit_from     => [ "VC-WIN64-common", asm("x86_64_asm"),
@@ -133,15 +133,15 @@ index 3c4299d264..c5915a8561 100644
          AS               => sub { vc_win64a_info()->{AS} },
          ASFLAGS          => sub { vc_win64a_info()->{ASFLAGS} },
          asoutflag        => sub { vc_win64a_info()->{asoutflag} },
-@@ -1312,7 +1312,7 @@ my %targets = (
+@@ -1334,7 +1334,7 @@ my %targets = (
      },
      "VC-WIN32" => {
          inherit_from     => [ "VC-noCE-common", asm("x86_asm"),
 -                              sub { $disabled{shared} ? () : "uplink_common" } ],
 +                              sub { $disabled{uplink} ? () : "uplink_common" } ],
-         CFLAGS           => add("/WX"),
          AS               => sub { vc_win32_info()->{AS} },
          ASFLAGS          => sub { vc_win32_info()->{ASFLAGS} },
+         asoutflag        => sub { vc_win32_info()->{asoutflag} },
 diff --git a/Configurations/50-win-onecore.conf b/Configurations/50-win-onecore.conf
 index d478f42b0f..9ce0f6870b 100644
 --- a/Configurations/50-win-onecore.conf
@@ -227,7 +227,7 @@ index 5a699836f3..859b9f4ad9 100755
  # enable-weak-ssl-ciphers
  #               Enable weak ciphers that are disabled by default.
  # 386           generate 80386 code in assembly modules
-@@ -407,6 +408,7 @@ my @disablables = (
+@@ -430,6 +431,7 @@ my @disablables = (
      "ubsan",
      "ui-console",
      "unit-test",
@@ -235,20 +235,20 @@ index 5a699836f3..859b9f4ad9 100755
      "whirlpool",
      "weak-ssl-ciphers",
      "zlib",
-@@ -1118,6 +1118,8 @@ foreach my $feature (@{$target{enable}}) {
+@@ -1135,6 +1135,8 @@ foreach my $feature (@{$target{enable}}) {
          delete $disabled{$feature};
      }
  }
 +# If uplink_arch isn't defined, disable uplink
 +$disabled{uplink} = 'no uplink_arch' unless (defined $target{uplink_arch});
-
+ disable();                      # Run a cascade now
+ 
  $target{CXXFLAGS}//=$target{CFLAGS} if $target{CXX};
- $target{cxxflags}//=$target{cflags} if $target{CXX};
 diff --git a/INSTALL b/INSTALL
 index 2119cbae9e..51a7cd2f0b 100644
 --- a/INSTALL
 +++ b/INSTALL
-@@ -540,6 +540,9 @@
+@@ -544,6 +544,9 @@
                     Enable additional unit test APIs. This should not typically
                     be used in production deployments.
  


### PR DESCRIPTION
@Paxxi 

After a little big nightmare I archived obtain a functional build of Python 3.8.15 tested on both Windows x64 and Xbox

The reason is try to fix latest Python related issues on Xbox: 
https://forum.kodi.tv/showthread.php?tid=369438

In addition to Python 3.8.15 fixes and improvements, "Kodi patches 3" avoids link `Shlwapi.lib` on UWP build (now only is used on desktop build). I think it is likely that this is one of the causes or the root cause of the issues. It also coincides that it is since Xbox uses an OS based on Windows 11 22H2 (same build number 22621).

Kodi patches applies clean on top of untouched Python 3.8 branch as is in: https://github.com/thexai/cpython/commits/kodi/3.8

Maybe it would be better update your branch instead of pointing to my repo, in any case this does not matter to me.

Need to disabling arm64 builds is unrelated to Python bump, seems a "glitch" in CI (maybe temporal) but I have not managed to finish a build without this. Seems related to "timing" issues due cmake parallels builds  (anyway `arm64` Desktop and App are not used at all).
