### PR TITLE
Bump libbluray to 1.3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -866,7 +866,7 @@ add_dependency_project_package(libudfread 1.1.2)
 ExternalProject_Add(libbluray
     DEPENDS freetype libiconv libxml2 libudfread libaacs
     GIT_REPOSITORY https://code.videolan.org/videolan/libbluray.git
-    GIT_TAG 8e501bcab48b402653be3ca8ec103217098eb477
+    GIT_TAG bb5bc108ec695889855f06df338958004ff289ef
     GIT_SHALLOW ON
     PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     CMAKE_ARGS
@@ -874,7 +874,7 @@ ExternalProject_Add(libbluray
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
         -DCMAKE_PREFIX_PATH:PATH=${PREFIX}%3B%3B${PREFIX}/freetype%3B%3B${PREFIX}/libiconv%3B%3B${PREFIX}/libxml2%3B%3B${PREFIX}/libudfread
 )
-add_dependency_project_package(libbluray 1.3.2)
+add_dependency_project_package(libbluray 1.3.4)
 
 ExternalProject_Add(dav1d
     DOWNLOAD_NAME dav1d-1.2.0.tar.gz


### PR DESCRIPTION
Patch seems to apply just fine. This version mostly brings fixes to BSD anyway.
Checking if it builds fine for a runtime test later on.