### PR TITLE
Bump dav1d to 1.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -877,14 +877,16 @@ ExternalProject_Add(libbluray
 add_dependency_project_package(libbluray 1.3.2)
 
 ExternalProject_Add(dav1d
-    GIT_REPOSITORY https://github.com/Paxxi/dav1d
-    GIT_TAG d3dea2705a9cb64939a8336eef0b7ea98ff71f64
-    GIT_SHALLOW ON
+    DOWNLOAD_NAME dav1d-1.2.0.tar.gz
+    DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
+    URL https://code.videolan.org/videolan/dav1d/-/archive/1.2.0/dav1d-1.2.0.tar.gz
+    URL_HASH SHA256=88669c6113ddfda068f03bf8e864e4e6a1ea2e2480afec86d1bf91a8c600e79d
+    PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
 )
-add_dependency_project_package(dav1d 0.8.2)
+add_dependency_project_package(dav1d 1.2.0)
 
 ExternalProject_Add(GoogleTest
     GIT_REPOSITORY https://github.com/Google/GoogleTest

--- a/patches/dav1d.diff
+++ b/patches/dav1d.diff
@@ -1,0 +1,526 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..9867cb9
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,439 @@
++cmake_minimum_required(VERSION 3.15)
++
++project(dav1d VERSION 1.2.0 LANGUAGES C ASM)
++
++include(CheckSymbolExists)
++check_symbol_exists(_X86_ "Windows.h" _X86_)
++check_symbol_exists(_AMD64_ "Windows.h" _AMD64_)
++check_symbol_exists(_ARM_ "Windows.h" _ARM_)
++check_symbol_exists(_ARM64_ "Windows.h" _ARM64_)
++
++set(DAV1D_API_VERSION_MAJOR 6)
++set(DAV1D_API_VERSION_MINOR 9)
++set(DAV1D_API_VERSION_PATCH 0)
++
++set(COPYRIGHT_YEARS 2018-2023)
++
++set(PROJECT_VERSION_REVISION ${PROJECT_VERSION_PATCH})
++set(API_VERSION_MAJOR ${DAV1D_API_VERSION_MAJOR})
++set(API_VERSION_MINOR ${DAV1D_API_VERSION_MINOR})
++set(API_VERSION_REVISION ${DAV1D_API_VERSION_PATCH})
++
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/dav1d.rc.in
++               ${CMAKE_CURRENT_BINARY_DIR}/dav1d.rc)
++
++include(FindGit)
++if(GIT_EXECUTABLE AND EXISTS ${CMAKE_CURRENT_LIST_DIR}/.git)
++  execute_process(
++    COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
++      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
++       OUTPUT_VARIABLE OUT RESULT_VARIABLE RES)
++   IF(RES EQUAL 0)
++    string(REGEX REPLACE "\n$" "" VCS_TAG "${OUT}")
++  endif()
++endif()
++
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/vcs_version.h.in
++               ${CMAKE_CURRENT_SOURCE_DIR}/include/vcs_version.h)
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/dav1d/version.h.in
++               ${CMAKE_CURRENT_SOURCE_DIR}/include/dav1d/version.h)
++
++set(STACK_ALIGNMENT 0)
++set(ARCH_AARCH64 0)
++set(HAVE_PREFIX 0)
++set(ARCH_X86 0)
++set(HAVE_ASM 0)
++set(ARCH_X86_32 0)
++set(ARCH_X86_64 0)
++if(_ARM64_)
++  set(ARCH_AARCH64 1)
++  set(HAVE_PREFIX 1)
++endif()
++set(ARCH_ARM 0)
++if(_ARM_)
++  set(ARCH_ARM 1)
++  set(HAVE_PREFIX 1)
++endif()
++if(_X86_ OR _AMD64_)
++  set(ARCH_X86 1)
++  set(HAVE_ASM 1)
++endif()
++if(_X86_)
++  set(ARCH_X86_32 1)
++  set(STACK_ALIGNMENT 4)
++  set(HAVE_PREFIX 1)
++endif()
++if(_AMD64_)
++  set(ARCH_X86_64 1)
++  set(STACK_ALIGNMENT 16)
++endif()
++
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.h.cmakein
++               ${CMAKE_CURRENT_BINARY_DIR}/config.h)
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.asm.cmakein
++               ${CMAKE_CURRENT_BINARY_DIR}/config.asm)
++
++# libdav1d source files
++set(libdav1d_sources
++    src/cdf.c
++    src/cpu.c
++    src/data.c
++    src/decode.c
++    src/dequant_tables.c
++    src/getbits.c
++    src/intra_edge.c
++    src/itx_1d.c
++    src/lf_mask.c
++    src/lib.c
++    src/log.c
++    src/mem.c
++    src/msac.c
++    src/obu.c
++    src/picture.c
++    src/qm.c
++    src/ref.c
++    src/refmvs.c
++    src/scan.c
++    src/tables.c
++    src/thread_task.c
++    src/warpmv.c
++    src/wedge.c
++    src/win32/thread.c
++)
++
++# libdav1d rc file
++set(libdav1d_rc
++    ${CMAKE_CURRENT_BINARY_DIR}/dav1d.rc
++)
++
++# libdav1d bitdepth source files
++# These files are compiled for each bitdepth with
++# `BITDEPTH` defined to the currently built bitdepth.
++set(libdav1d_tmpl_sources
++    src/cdef_apply_tmpl.c
++    src/cdef_tmpl.c
++    src/fg_apply_tmpl.c
++    src/filmgrain_tmpl.c
++    src/ipred_prepare_tmpl.c
++    src/ipred_tmpl.c
++    src/itx_tmpl.c
++    src/lf_apply_tmpl.c
++    src/loopfilter_tmpl.c
++    src/looprestoration_tmpl.c
++    src/lr_apply_tmpl.c
++    src/mc_tmpl.c
++    src/recon_tmpl.c
++)
++
++set(libdav1d_arch_tmpl_sources)
++
++set(libdav1d_bitdepth_objs)
++
++# ASM specific sources
++set(libdav1d_nasm_objs)
++# Arch-specific flags
++set(arch_flags)
++if (_ARM64_ OR _ARM_)
++  list(APPEND libdav1d_sources
++    src/arm/cpu.c
++  )
++  if(_ARM64_)
++    list(APPEND libdav1d_sources_asm
++      # itx.S is used for both 8 and 16 bpc.
++      src/arm/64/itx.S
++      src/arm/64/looprestoration_common.S
++      src/arm/64/msac.S
++      src/arm/64/refmvs.S
++    )
++    list(APPEND libdav1d_sources8_asm
++      src/arm/64/cdef.S
++      src/arm/64/filmgrain.S
++      src/arm/64/ipred.S
++      src/arm/64/loopfilter.S
++      src/arm/64/looprestoration.S
++      src/arm/64/mc.S
++    )
++    list(APPEND libdav1d_sources16_asm
++      src/arm/64/cdef16.S
++      src/arm/64/filmgrain16.S
++      src/arm/64/ipred16.S
++      src/arm/64/itx16.S
++      src/arm/64/loopfilter16.S
++      src/arm/64/looprestoration16.S
++      src/arm/64/mc16.S
++    )
++  elseif(_ARM_)
++    list(APPEND libdav1d_sources_asm
++      # itx.S is used for both 8 and 16 bpc.
++      src/arm/32/itx.S
++      src/arm/32/looprestoration_common.S
++      src/arm/32/msac.S
++      src/arm/32/refmvs.S
++    )
++    list(APPEND libdav1d_sources8_asm
++      src/arm/32/cdef.S
++      src/arm/32/filmgrain.S
++      src/arm/32/ipred.S
++      src/arm/32/loopfilter.S
++      src/arm/32/looprestoration.S
++      src/arm/32/mc.S
++    )
++    list(APPEND libdav1d_sources16_asm
++      src/arm/32/cdef16.S
++      src/arm/32/filmgrain16.S
++      src/arm/32/ipred16.S
++      src/arm/32/itx16.S
++      src/arm/32/loopfilter16.S
++      src/arm/32/looprestoration16.S
++      src/arm/32/mc16.S
++    )
++  endif()
++elseif(_X86_ OR _AMD64_)
++  enable_language(ASM_NASM)
++  list(APPEND libdav1d_sources
++    src/x86/cpu.c
++  )
++
++  # NASM source files
++  list(APPEND libdav1d_sources_asm
++    src/x86/cpuid.asm
++    src/x86/msac.asm
++    src/x86/refmvs.asm
++    src/x86/itx_avx512.asm
++    src/x86/cdef_avx2.asm
++    src/x86/itx_avx2.asm
++    src/x86/looprestoration_avx2.asm
++    src/x86/cdef_sse.asm
++    src/x86/itx_sse.asm
++  )
++
++  list(APPEND libdav1d_sources8_asm
++    src/x86/cdef_avx512.asm
++    src/x86/filmgrain_avx512.asm
++    src/x86/ipred_avx512.asm
++    src/x86/loopfilter_avx512.asm
++    src/x86/looprestoration_avx512.asm
++    src/x86/mc_avx512.asm
++    src/x86/filmgrain_avx2.asm
++    src/x86/ipred_avx2.asm
++    src/x86/loopfilter_avx2.asm
++    src/x86/mc_avx2.asm
++    src/x86/filmgrain_sse.asm
++    src/x86/ipred_sse.asm
++    src/x86/loopfilter_sse.asm
++    src/x86/looprestoration_sse.asm
++    src/x86/mc_sse.asm
++  )
++
++  list(APPEND libdav1d_sources16_asm
++    src/x86/cdef16_avx512.asm
++    src/x86/filmgrain16_avx512.asm
++    src/x86/ipred16_avx512.asm
++    src/x86/itx16_avx512.asm
++    src/x86/loopfilter16_avx512.asm
++    src/x86/looprestoration16_avx512.asm
++    src/x86/mc16_avx512.asm
++    src/x86/cdef16_avx2.asm
++    src/x86/filmgrain16_avx2.asm
++    src/x86/ipred16_avx2.asm
++    src/x86/itx16_avx2.asm
++    src/x86/loopfilter16_avx2.asm
++    src/x86/looprestoration16_avx2.asm
++    src/x86/mc16_avx2.asm
++    src/x86/cdef16_sse.asm
++    src/x86/filmgrain16_sse.asm
++    src/x86/ipred16_sse.asm
++    src/x86/itx16_sse.asm
++    src/x86/loopfilter16_sse.asm
++    src/x86/looprestoration16_sse.asm
++    src/x86/mc16_sse.asm
++  )
++endif()
++
++set_source_files_properties(${libdav1d_sources} PROPERTIES COMPILE_FLAGS "/MP /sdl- /wd4090")
++
++set_source_files_properties(${libdav1d_tmpl_sources} PROPERTIES COMPILE_FLAGS "/MP /sdl-")
++
++add_library(dav1d SHARED
++  ${libdav1d_sources}
++  ${libdav1d_nasm_objs}
++  ${libdav1d_rc}
++)
++
++add_library(dav1d_bitdepth_8 STATIC
++  ${libdav1d_sources_asm}
++  ${libdav1d_sources8_asm}
++  ${libdav1d_tmpl_sources}
++  ${libdav1d_arch_tmpl_sources}
++)
++
++add_library(dav1d_bitdepth_16 STATIC
++  ${libdav1d_sources_asm}
++  ${libdav1d_sources16_asm}
++  ${libdav1d_tmpl_sources}
++  ${libdav1d_arch_tmpl_sources}
++)
++
++target_compile_definitions(dav1d
++  PRIVATE
++    _CRT_SECURE_NO_WARNINGS
++    _CRT_NONSTDC_NO_WARNINGS
++    __PRETTY_FUNCTION__=__FUNCTION__
++    DAV1D_BUILDING_DLL
++)
++
++target_compile_definitions(dav1d_bitdepth_8
++  PRIVATE
++    BITDEPTH=8
++    _CRT_SECURE_NO_WARNINGS
++)
++target_compile_definitions(dav1d_bitdepth_16
++  PRIVATE
++    BITDEPTH=16
++    _CRT_SECURE_NO_WARNINGS
++)
++if(_X86_)
++  target_compile_definitions(dav1d
++    PRIVATE
++      PREFIX=1
++  )
++
++  target_compile_definitions(dav1d_bitdepth_8
++    PRIVATE
++      PREFIX=1
++      HAVE_AVX512ICL=1
++  )
++  target_compile_definitions(dav1d_bitdepth_16
++    PRIVATE
++      PREFIX=1
++      HAVE_AVX512ICL=1
++  )
++endif()
++if(_AMD64_)
++  target_compile_definitions(dav1d
++    PRIVATE
++      ARCH_X86_64=1
++      HAVE_AVX512ICL=1
++  )
++  target_compile_definitions(dav1d_bitdepth_8
++    PRIVATE
++      ARCH_X86_64=1
++      HAVE_AVX512ICL=1
++  )
++  target_compile_definitions(dav1d_bitdepth_16
++    PRIVATE
++      ARCH_X86_64=1
++      HAVE_AVX512ICL=1
++  )
++endif()
++
++if(WINDOWS_STORE)
++  target_compile_definitions(dav1d
++    PRIVATE
++      MS_APP
++      HAVE_AVX512ICL=1
++  )
++else()
++target_compile_definitions(dav1d
++  PRIVATE
++    _WIN32_IE=_WIN32_WINNT_WINBLUE
++    _WIN32_WINNT=_WIN32_WINNT_WINBLUE
++    HAVE_AVX512ICL=1
++)
++target_link_libraries(dav1d
++    PRIVATE
++    shell32.lib
++  )
++endif()
++
++target_link_libraries(dav1d
++  PRIVATE
++    kernel32.lib
++    dav1d_bitdepth_8
++    dav1d_bitdepth_16
++)
++
++target_link_options(dav1d
++  PRIVATE
++    /debug:full
++)
++
++target_include_directories(dav1d_bitdepth_16
++  PRIVATE
++  $<BUILD_INTERFACE:.;cmake;src;src/util;${CMAKE_CURRENT_BINARY_DIR};include;include/compat/msvc;include/dav1d>
++  INTERFACE
++  $<INSTALL_INTERFACE:include/dav1d>
++)
++
++target_include_directories(dav1d_bitdepth_8
++  PRIVATE
++  $<BUILD_INTERFACE:.;cmake;src;src/util;${CMAKE_CURRENT_BINARY_DIR};include;include/compat/msvc;include/dav1d>
++  INTERFACE
++  $<INSTALL_INTERFACE:include/dav1d>
++)
++
++target_include_directories(dav1d
++  PRIVATE
++  $<BUILD_INTERFACE:.;cmake;src;src/util;${CMAKE_CURRENT_BINARY_DIR};include;include/compat/msvc;include/dav1d>
++  INTERFACE
++  $<INSTALL_INTERFACE:include/dav1d>
++)
++
++include(CMakePackageConfigHelpers)
++write_basic_package_version_file(
++  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
++  VERSION ${PROJECT_VERSION}
++  COMPATIBILITY AnyNewerVersion
++)
++
++include(CMakePackageConfigHelpers)
++write_basic_package_version_file(
++  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
++  VERSION ${PROJECT_VERSION}
++  COMPATIBILITY AnyNewerVersion
++)
++
++install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
++  RUNTIME DESTINATION bin
++  LIBRARY DESTINATION lib
++  ARCHIVE DESTINATION lib
++)
++
++install(DIRECTORY include/ DESTINATION include)
++
++if(MSVC)
++  set_target_properties(dav1d
++    PROPERTIES
++      COMPILE_PDB_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
++      COMPILE_PDB_NAME libdav1d
++      PDB_NAME libdav1d
++      OUTPUT_NAME libdav1d
++  )
++  install(FILES
++    ${PROJECT_BINARY_DIR}/RelWithDebInfo/libdav1d.pdb
++    DESTINATION lib
++    CONFIGURATIONS RelWithDebInfo
++  )
++  install(FILES
++    ${PROJECT_BINARY_DIR}/Debug/libdav1d.pdb
++    DESTINATION lib
++    CONFIGURATIONS Debug
++  )
++endif()
++
++install(EXPORT ${PROJECT_NAME}
++  FILE
++    ${PROJECT_NAME}.cmake
++  NAMESPACE
++    ${PROJECT_NAME}::
++  DESTINATION
++    lib/cmake/${PROJECT_NAME}
++)
++
++install(
++  FILES
++    cmake/${PROJECT_NAME}-config.cmake
++    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
++  DESTINATION
++    lib/cmake/${PROJECT_NAME}
++)
+diff --git a/cmake/config.asm.cmakein b/cmake/config.asm.cmakein
+new file mode 100644
+index 0000000..7fadfc0
+--- /dev/null
++++ b/cmake/config.asm.cmakein
+@@ -0,0 +1,15 @@
++; Autogenerated by the Meson build system.
++; Do not edit, your changes will be lost.
++
++%define ARCH_X86_32 @ARCH_X86_32@
++
++%define ARCH_X86_64 @ARCH_X86_64@
++
++%define PIC 1
++
++%define HAVE_PREFIX @HAVE_PREFIX@
++
++%define private_prefix dav1d
++
++%define STACK_ALIGNMENT @STACK_ALIGNMENT@
++
+diff --git a/cmake/config.h.cmakein b/cmake/config.h.cmakein
+new file mode 100644
+index 0000000..64be7f8
+--- /dev/null
++++ b/cmake/config.h.cmakein
+@@ -0,0 +1,47 @@
++/*
++ * Autogenerated by the Meson build system.
++ * Do not edit, your changes will be lost.
++ */
++
++#pragma once
++
++#define ARCH_AARCH64 @ARCH_AARCH64@
++#define ARCH_ARM @ARCH_ARM@
++#define ARCH_PPC64LE 0
++
++#define ARCH_X86 @ARCH_X86@
++
++#define ARCH_X86_32 @ARCH_X86_32@
++
++#define ARCH_X86_64 @ARCH_X86_64@
++
++#define CONFIG_16BPC 1
++
++#define CONFIG_8BPC 1
++
++#define CONFIG_LOG 1
++
++#define ENDIANNESS_BIG 0
++
++#define HAVE_ALIGNED_MALLOC 1
++
++#define HAVE_ASM @HAVE_ASM@
++
++#define HAVE_IO_H 1
++
++#define HAVE_UNISTD_H 1
++
++#define STACK_ALIGNMENT @STACK_ALIGNMENT@
++
++#define UNICODE 1
++
++#define _CRT_DECLARE_NONSTDC_NAMES 1
++
++#define _FILE_OFFSET_BITS 64
++
++#define _UNICODE 1
++
++// #define _WIN32_WINNT 0x0601
++
++#define __USE_MINGW_ANSI_STDIO 1
++
+diff --git a/cmake/dav1d-config.cmake b/cmake/dav1d-config.cmake
+new file mode 100644
+index 0000000..e172841
+--- /dev/null
++++ b/cmake/dav1d-config.cmake
+@@ -0,0 +1 @@
++include(${CMAKE_CURRENT_LIST_DIR}/dav1d.cmake)


### PR DESCRIPTION
@Paxxi 

This updates dav1d to latest ~1.1.0~ 1.2.0 that is big improvement from 0.8.2 we are using in Windows. It has many new assembler optimizations and better overall performance.

I changed a bit the format and now code is taken directly from upstream and `CMakeLists.txt` is created in a patch.

Some relevant changes besides updated file tree is that CMake 3.26 seems is not accepting passing compile options globally e.g. `target_compile_options(dav1d  PRIVATE  /sdl-)` because this breaks NASM compilation.

Then are passed only to *.c files:

`set_source_files_properties(${libdav1d_sources} PROPERTIES COMPILE_FLAGS "/MP /sdl- /wd4090")`