### PR TITLE
[github] Updated deprecated workflows actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install Strawberry Perl
       # Perl included with git does not work when building openssl
@@ -35,9 +35,9 @@ jobs:
       run: .\DoRelease.ps1 -Platforms ${{ matrix.arch }} ${{ matrix.platform }} -VsVersion ${{ env.VS_VERSION }} -SdkVersion "${{ env.SDK_VERSION }}"
 
     - name: Archive artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: Kodi dependencies
+        name: Kodi dependencies ${{ matrix.arch }}${{ matrix.platform }}
         path: |
           package/*.7z
           package/hashes-*.txt


### PR DESCRIPTION
v2 of workflows are being deprecated. Updated to v4

The upload-artifact action is now updated to v4. In order to move to v4 a separate archive is required for each job.