### PR TITLE
Bump dav1d to v1.4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
       # Perl included with git does not work when building openssl
       run: choco install -y StrawberryPerl nasm
 
+    - name: Install CMake v3.28.3
+      # libbluray fails to build with CMake 3.29.0
+      run: choco install -y CMake --version 3.28.3 --force
+
     - name: Build
       # Build your program with the given configuration
       run: .\DoRelease.ps1 -Platforms ${{ matrix.arch }} ${{ matrix.platform }} -VsVersion ${{ env.VS_VERSION }} -SdkVersion "${{ env.SDK_VERSION }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -877,16 +877,16 @@ ExternalProject_Add(libbluray
 add_dependency_project_package(libbluray 1.3.4)
 
 ExternalProject_Add(dav1d
-    DOWNLOAD_NAME dav1d-1.2.0.tar.gz
+    DOWNLOAD_NAME dav1d-1.4.1.tar.gz
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
-    URL https://code.videolan.org/videolan/dav1d/-/archive/1.2.0/dav1d-1.2.0.tar.gz
-    URL_HASH SHA256=88669c6113ddfda068f03bf8e864e4e6a1ea2e2480afec86d1bf91a8c600e79d
+    URL https://code.videolan.org/videolan/dav1d/-/archive/1.4.1/dav1d-1.4.1.tar.gz
+    URL_HASH SHA256=04da7689748a3501d00b6796b6de0596177019709ecc6095c667b7964895dd8c
     PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
 )
-add_dependency_project_package(dav1d 1.2.0)
+add_dependency_project_package(dav1d 1.4.1)
 
 ExternalProject_Add(GoogleTest
     GIT_REPOSITORY https://github.com/Google/GoogleTest

--- a/patches/dav1d.diff
+++ b/patches/dav1d.diff
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 new file mode 100644
-index 0000000..9867cb9
+index 0000000..d5a74f1
 --- /dev/null
 +++ b/CMakeLists.txt
-@@ -0,0 +1,439 @@
+@@ -0,0 +1,441 @@
 +cmake_minimum_required(VERSION 3.15)
 +
-+project(dav1d VERSION 1.2.0 LANGUAGES C ASM)
++project(dav1d VERSION 1.4.1 LANGUAGES C ASM)
 +
 +include(CheckSymbolExists)
 +check_symbol_exists(_X86_ "Windows.h" _X86_)
@@ -14,11 +14,11 @@ index 0000000..9867cb9
 +check_symbol_exists(_ARM_ "Windows.h" _ARM_)
 +check_symbol_exists(_ARM64_ "Windows.h" _ARM64_)
 +
-+set(DAV1D_API_VERSION_MAJOR 6)
-+set(DAV1D_API_VERSION_MINOR 9)
++set(DAV1D_API_VERSION_MAJOR 7)
++set(DAV1D_API_VERSION_MINOR 0)
 +set(DAV1D_API_VERSION_PATCH 0)
 +
-+set(COPYRIGHT_YEARS 2018-2023)
++set(COPYRIGHT_YEARS 2018-2024)
 +
 +set(PROJECT_VERSION_REVISION ${PROJECT_VERSION_PATCH})
 +set(API_VERSION_MAJOR ${DAV1D_API_VERSION_MAJOR})
@@ -95,6 +95,7 @@ index 0000000..9867cb9
 +    src/mem.c
 +    src/msac.c
 +    src/obu.c
++    src/pal.c
 +    src/picture.c
 +    src/qm.c
 +    src/ref.c
@@ -205,6 +206,7 @@ index 0000000..9867cb9
 +    src/x86/cpuid.asm
 +    src/x86/msac.asm
 +    src/x86/refmvs.asm
++    src/x86/pal.asm
 +    src/x86/itx_avx512.asm
 +    src/x86/cdef_avx2.asm
 +    src/x86/itx_avx2.asm


### PR DESCRIPTION
This is the same as https://github.com/xbmc/xbmc/pull/24908 for Windows

Runtime tested Windows x64 and UWP