### PR TITLE
Bump Python to 3.13.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,13 @@ jobs:
 
     - name: Install Strawberry Perl
       # Perl included with git does not work when building openssl
-      run: choco install -y StrawberryPerl nasm
+      run: choco install -y StrawberryPerl
+
+    - name: Install nasm and add to path
+      # required to build OpenSSL with asm option enabled
+      run: |
+        choco install nasm ${{ matrix.platform.arch == 'win32' && '--x86' || '' }}
+        "C:\Program Files${{ matrix.platform.arch == 'win32' && ' (x86)' || '' }}\NASM" | Out-File -FilePath "$env:GITHUB_PATH" -Append
 
     - name: Install CMake v3.28.3
       # libbluray fails to build with CMake 3.29.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,8 +143,8 @@ add_dependency_project_package(bzip2 1.0.8)
 
 ExternalProject_Add(expat
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
-    URL https://github.com/libexpat/libexpat/archive/R_2_4_9.tar.gz
-    URL_HASH SHA256=286bb78d8800f20b5da0ff48d98d6c67a16242cfe8cc823a04998f94b5253279
+    URL https://github.com/libexpat/libexpat/archive/R_2_7_1.tar.gz
+    URL_HASH SHA256=85372797ff0673a8fc4a6be16466bb5a0ca28c0dcf3c6f7ac1686b4a3ba2aabb
     PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     UPDATE_DISCONNECTED ON
     CMAKE_ARGS
@@ -157,7 +157,7 @@ ExternalProject_Add(expat
         -DEXPAT_SHARED_LIBS:BOOL=OFF
   SOURCE_SUBDIR expat
 )
-add_dependency_project_package(expat 2.4.9)
+add_dependency_project_package(expat 2.7.1)
 
 ExternalProject_Add(libiconv
     GIT_REPOSITORY https://github.com/Paxxi/libiconv
@@ -173,40 +173,38 @@ add_dependency_project_package(libiconv 1.16)
 
 ExternalProject_Add(openssl
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
-    URL https://www.openssl.org/source/openssl-1.1.1q.tar.gz
-    URL_HASH SHA256=d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca
+    URL https://www.openssl.org/source/openssl-3.0.17.tar.gz
+    URL_HASH SHA256=dfdd77e4ea1b57ff3a6dbde6b0bdc3f31db5ac99e7fdd4eaf9e1fbb6ec2db8ce
     PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
 )
-add_dependency_project_package(openssl 1.1.1q)
+add_dependency_project_package(openssl 3.0.17)
 
 ExternalProject_Add(zlib
-    GIT_REPOSITORY https://github.com/Paxxi/zlib
-    GIT_TAG 1b8fe34fdd7b08da4629783d865df13dd2217bc8
-    GIT_SHALLOW ON
+    DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
+    URL https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
+    URL_HASH SHA256=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+    PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
-        -DBUILD_EXAMPLES:BOOL=OFF
-        -DBUILD_SHARED_LIBS:BOOL=OFF
+        -DZLIB_BUILD_EXAMPLES:BOOL=OFF
         -DSKIP_INSTALL_FILES:BOOL=ON
-        -DASM686:BOOL=OFF
-        -DAMD64:BOOL=OFF
 )
-add_dependency_project_package(zlib 1.2.11)
+add_dependency_project_package(zlib 1.3.1)
 
 ExternalProject_Add(xz
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
-    URL https://netix.dl.sourceforge.net/project/lzmautils/xz-5.2.4.tar.gz
-    URL_HASH SHA256=b512f3b726d3b37b6dc4c8570e137b9311e7552e8ccbab4d39d47ce5f4177145
+    URL https://netix.dl.sourceforge.net/project/lzmautils/xz-5.2.5.tar.gz
+    URL_HASH SHA256=f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10
     PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
 )
-add_dependency_project_package(xz 5.2.4)
+add_dependency_project_package(xz 5.2.5)
 
 ExternalProject_Add(miniwdk
     GIT_REPOSITORY https://github.com/Paxxi/miniwdk
@@ -305,15 +303,15 @@ add_dependency_project_package(harfbuzz 2.8.0)
 
 ExternalProject_Add(sqlite
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
-    URL https://sqlite.org/2019/sqlite-amalgamation-3300100.zip
-    URL_HASH SHA256=adf051d4c10781ea5cfabbbc4a2577b6ceca68590d23b58b8260a8e24cc5f081
+    URL https://www.sqlite.org/2025/sqlite-amalgamation-3500300.zip
+    URL_HASH SHA256=9ad6d16cbc1df7cd55c8b55127c82a9bca5e9f287818de6dc87e04e73599d754
     PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
-        -DBUILD_SHARED_LIBS:BOOL=OFF
+        -DBUILD_SHARED_LIBS:BOOL=ON
 )
-add_dependency_project_package(sqlite 3300100)
+add_dependency_project_package(sqlite 3500300)
 
 ExternalProject_Add(tinyxml
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
@@ -522,14 +520,14 @@ ExternalProject_Add(libwebp
 add_dependency_project_package(libwebp 1.0.3)
 
 ExternalProject_Add(mariadb-connector-c
-    DEPENDS openssl uwp_compat
-    GIT_REPOSITORY https://github.com/Paxxi/mariadb-connector-c
-    GIT_TAG f26c0be86e7f534996f62646f9015da504515d11
+    DEPENDS openssl
+    GIT_REPOSITORY https://github.com/thexai/mariadb-connector-c
+    GIT_TAG 1ad1ad6b25a95950ed7b81907a2ed28553d47343
     GIT_SHALLOW ON
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
-        -DCMAKE_PREFIX_PATH:PATH=${PREFIX}%3B%3B${PREFIX}/openssl%3B%3B${PREFIX}/uwp_compat
+        -DCMAKE_PREFIX_PATH:PATH=${PREFIX}%3B%3B${PREFIX}/openssl
         -DBUILD_SHARED_LIBS:BOOL=ON
         -DPLUGIN_AUTH_GSSAPI_CLIENT:STRING=OFF
         -DPLUGIN_DIALOG:STRING=STATIC
@@ -544,7 +542,7 @@ ExternalProject_Add(mariadb-connector-c
         -DWITH_SSL:STRING=OPENSSL
         -DWITH_UNIT_TESTS:BOOL=OFF
 )
-add_dependency_project_package(mariadb-connector-c 3.1.6)
+add_dependency_project_package(mariadb-connector-c 3.3.15)
 
 ExternalProject_Add(libffi
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
@@ -560,14 +558,14 @@ add_dependency_project_package(libffi 3.3.0)
 ExternalProject_Add(python
     DEPENDS bzip2 openssl sqlite zlib expat libffi xz
     GIT_REPOSITORY https://github.com/thexai/cpython
-    GIT_TAG 4c97e13f50ce1f925e5f95945c6d395b83f78a64
+    GIT_TAG ac18623a47b8c3d6bfe1ef5923ea37ca6635ab05
     GIT_SHALLOW ON
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
         -DCMAKE_PREFIX_PATH:PATH=${PREFIX}%3B%3B${PREFIX}/bzip2%3B%3B${PREFIX}/openssl%3B%3B${PREFIX}/sqlite%3B%3B${PREFIX}/zlib%3B%3B${PREFIX}/libffi%3B%3B${PREFIX}/xz%3B%3B${PREFIX}/expat
 )
-add_dependency_project_package(python 3.12.11)
+add_dependency_project_package(python 3.13.5)
 
 ExternalProject_Add(libjpeg-turbo
     GIT_REPOSITORY https://github.com/Paxxi/libjpeg-turbo

--- a/patches/expat.diff
+++ b/patches/expat.diff
@@ -1,8 +1,17 @@
-﻿diff --git a/expat/CMakeLists.txt b/expat/CMakeLists.txt
-index 3417b69..7925ba1 100644
+diff --git a/expat/CMakeLists.txt b/expat/CMakeLists.txt
+index 386b66ab..e22bb3a0 100644
 --- a/expat/CMakeLists.txt
 +++ b/expat/CMakeLists.txt
-@@ -490,7 +490,8 @@ endif(NOT WIN32)
+@@ -375,7 +375,7 @@ endif()
+ 
+ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+ if(MSVC)
+-    add_definitions(-D_CRT_SECURE_NO_WARNINGS -wd4996)
++    add_definitions(-D_CRT_SECURE_NO_WARNINGS -wd4996 /sdl-)
+ endif()
+ 
+ #
+@@ -518,7 +518,8 @@ endif()
  expat_install(TARGETS expat EXPORT expat
                        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -12,7 +21,7 @@ index 3417b69..7925ba1 100644
  
  expat_install(FILES lib/expat.h lib/expat_external.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  
-@@ -807,13 +807,13 @@ expat_install(
+@@ -919,13 +920,13 @@ expat_install(
          ${CMAKE_CURRENT_BINARY_DIR}/cmake/expat-config.cmake
          ${CMAKE_CURRENT_BINARY_DIR}/cmake/expat-config-version.cmake
      DESTINATION

--- a/patches/openssl.diff
+++ b/patches/openssl.diff
@@ -1,36 +1,33 @@
-﻿diff --git a/CMakeLists.txt b/CMakeLists.txt
+diff --git a/CMakeLists.txt b/CMakeLists.txt
 new file mode 100644
-index 0000000000..a92d7101fb
+index 0000000000..937a38db86
 --- /dev/null
 +++ b/CMakeLists.txt
-@@ -0,0 +1,107 @@
-+cmake_minimum_required(VERSION 3.0)
+@@ -0,0 +1,106 @@
++cmake_minimum_required(VERSION 3.15)
 +
-+project(openssl VERSION 1.1.1 LANGUAGES C)
++project(openssl VERSION 3.0.17 LANGUAGES C)
 +
-+include(CheckSymbolExists) 
++include(CheckSymbolExists)
 +check_symbol_exists(_X86_ "Windows.h" _X86_)
 +check_symbol_exists(_AMD64_ "Windows.h" _AMD64_)
 +check_symbol_exists(_ARM_ "Windows.h" _ARM_)
 +check_symbol_exists(_ARM64_ "Windows.h" _ARM64_)
 +
 +if(_X86_)
-+	message(STATUS "Win32")
-+	set(OPENSSL_PLATFORM VC-WIN32)
++  message(STATUS "Win32")
++  set(OPENSSL_PLATFORM VC-WIN32)
 +elseif(_AMD64_)
-+	message(STATUS "x64")
-+	set(OPENSSL_PLATFORM VC-WIN64A)
-+elseif(_ARM_)
-+	message(STATUS "arm")
-+	set(OPENSSL_PLATFORM VC-WIN32-ARM)
++  message(STATUS "x64")
++  set(OPENSSL_PLATFORM VC-WIN64A)
 +elseif(_ARM64_)
-+	message(STATUS "arm64")
-+	set(OPENSSL_PLATFORM VC-WIN64-ARM)
++  message(STATUS "arm64")
++  set(OPENSSL_PLATFORM VC-WIN64-ARM)
 +else()
-+	message(FATAL_ERROR "Unsupported target architecture")
++  message(FATAL_ERROR "Unsupported target architecture")
 +endif()
 +
-+list(APPEND CONFIGURE_FLAGS disable-capieng enable-static-engine no-asm no-dso no-shared no-tests no-ui-console)
++list(APPEND CONFIGURE_FLAGS disable-capieng enable-static-engine no-dso no-shared no-tests no-ui-console)
 +if (WINDOWS_STORE)
 +  set(OPENSSL_PLATFORM "${OPENSSL_PLATFORM}-UWP")
 +  # See NOTES.WIN in openssl, says this is required for uwp
@@ -44,24 +41,24 @@ index 0000000000..a92d7101fb
 +
 +add_library(crypto INTERFACE)
 +target_link_libraries(crypto
-+	INTERFACE
-+	libcrypto.lib
++  INTERFACE
++  libcrypto.lib
 +)
 +
 +target_link_directories(crypto
-+	INTERFACE
-+	$<INSTALL_INTERFACE:lib>
++  INTERFACE
++  $<INSTALL_INTERFACE:lib>
 +)
 +
 +add_library(ssl INTERFACE)
 +target_link_libraries(ssl
-+	INTERFACE
-+	libssl.lib
++  INTERFACE
++  libssl.lib
 +)
 +
 +target_link_directories(ssl
-+	INTERFACE
-+	$<INSTALL_INTERFACE:lib>
++  INTERFACE
++  $<INSTALL_INTERFACE:lib>
 +)
 +
 +install(DIRECTORY include/openssl DESTINATION include/ FILES_MATCHING PATTERN "*.h")
@@ -74,17 +71,19 @@ index 0000000000..a92d7101fb
 +  COMPATIBILITY AnyNewerVersion
 +)
 +
-+install(TARGETS crypto EXPORT crypto 
++install(TARGETS crypto EXPORT crypto
 +  RUNTIME DESTINATION bin
 +  ARCHIVE DESTINATION lib
-+	LIBRARY DESTINATION lib
-+	INCLUDES DESTINATION include)
++  LIBRARY DESTINATION lib
++  INCLUDES DESTINATION include
++)
 +
-+install(TARGETS ssl EXPORT ssl 
++install(TARGETS ssl EXPORT ssl
 +  RUNTIME DESTINATION bin
 +  ARCHIVE DESTINATION lib
-+	LIBRARY DESTINATION lib
-+	INCLUDES DESTINATION include)
++  LIBRARY DESTINATION lib
++  INCLUDES DESTINATION include
++)
 +
 +install(EXPORT crypto
 +  FILE
@@ -111,196 +110,12 @@ index 0000000000..a92d7101fb
 +  DESTINATION
 +    lib/cmake/openssl
 +)
-diff --git a/Configurations/10-main.conf b/Configurations/10-main.conf
-index 3c4299d264..c5915a8561 100644
---- a/Configurations/10-main.conf
-+++ b/Configurations/10-main.conf
-@@ -1309,7 +1309,7 @@ my %targets = (
-     },
-     "VC-WIN64I" => {
-         inherit_from     => [ "VC-WIN64-common", asm("ia64_asm"),
--                              sub { $disabled{shared} ? () : "ia64_uplink" } ],
-+                              sub { $disabled{uplink} ? () : "ia64_uplink" } ],
-         AS               => "ias",
-         ASFLAGS          => "-d debug",
-         asoutflag        => "-o ",
-@@ -1321,7 +1321,7 @@ my %targets = (
-     },
-     "VC-WIN64A" => {
-         inherit_from     => [ "VC-WIN64-common", asm("x86_64_asm"),
--                              sub { $disabled{shared} ? () : "x86_64_uplink" } ],
-+                              sub { $disabled{uplink} ? () : "x86_64_uplink" } ],
-         AS               => sub { vc_win64a_info()->{AS} },
-         ASFLAGS          => sub { vc_win64a_info()->{ASFLAGS} },
-         asoutflag        => sub { vc_win64a_info()->{asoutflag} },
-@@ -1334,7 +1334,7 @@ my %targets = (
-     },
-     "VC-WIN32" => {
-         inherit_from     => [ "VC-noCE-common", asm("x86_asm"),
--                              sub { $disabled{shared} ? () : "uplink_common" } ],
-+                              sub { $disabled{uplink} ? () : "uplink_common" } ],
-         AS               => sub { vc_win32_info()->{AS} },
-         ASFLAGS          => sub { vc_win32_info()->{ASFLAGS} },
-         asoutflag        => sub { vc_win32_info()->{asoutflag} },
-diff --git a/Configurations/50-win-onecore.conf b/Configurations/50-win-onecore.conf
-index d478f42b0f..9ce0f6870b 100644
---- a/Configurations/50-win-onecore.conf
-+++ b/Configurations/50-win-onecore.conf
-@@ -61,4 +61,53 @@ my %targets = (
-         ex_libs         => "onecore.lib",
-         multilib        => "-arm64",
-     },
-+
-+    # Universal Windows Platform (UWP) App Support
-+
-+    # TODO
-+    #
-+    # The 'disable' attribute should have 'uplink'.
-+    # however, these are checked in some 'inherit_from', which is processed
-+    # very early, before the 'disable' attributes are seen.
-+    # This is a problem that needs to be resolved in Configure first.
-+    #
-+    # But if you want to build library with Windows 10 Version 1809 SDK or
-+    # earlier, the 'disable' attribute should also have 'asm'.
-+
-+    "VC-WIN32-UWP" => {
-+        inherit_from    => [ "VC-WIN32-ONECORE" ],
-+        lflags          => add("/APPCONTAINER"),
-+        defines         => add("WINAPI_FAMILY=WINAPI_FAMILY_APP",
-+                               "_WIN32_WINNT=0x0A00"),
-+        dso_scheme      => "",
-+        disable         => [ 'ui-console', 'async', 'uplink' ],
-+        ex_libs         => "WindowsApp.lib",
-+    },
-+     "VC-WIN64A-UWP" => {
-+        inherit_from    => [ "VC-WIN64A-ONECORE" ],
-+        lflags          => add("/APPCONTAINER"),
-+        defines         => add("WINAPI_FAMILY=WINAPI_FAMILY_APP",
-+                               "_WIN32_WINNT=0x0A00"),
-+        dso_scheme      => "",
-+        disable         => [ 'ui-console', 'async', 'uplink' ],
-+        ex_libs         => "WindowsApp.lib",
-+    },
-+    "VC-WIN32-ARM-UWP" => {
-+        inherit_from    => [ "VC-WIN32-ARM" ],
-+        lflags          => add("/APPCONTAINER"),
-+        defines         => add("WINAPI_FAMILY=WINAPI_FAMILY_APP",
-+                               "_WIN32_WINNT=0x0A00"),
-+        dso_scheme      => "",
-+        disable         => [ 'ui-console', 'async', 'uplink' ],
-+        ex_libs         => "WindowsApp.lib",
-+    },
-+     "VC-WIN64-ARM-UWP" => {
-+        inherit_from    => [ "VC-WIN64-ARM" ],
-+        lflags          => add("/APPCONTAINER"),
-+        defines         => add("WINAPI_FAMILY=WINAPI_FAMILY_APP",
-+                               "_WIN32_WINNT=0x0A00"),
-+        dso_scheme      => "",
-+        disable         => [ 'ui-console', 'async', 'uplink' ],
-+        ex_libs         => "WindowsApp.lib",
-+    },
- );
-diff --git a/Configurations/windows-makefile.tmpl b/Configurations/windows-makefile.tmpl
-index 8ef70b8699..b0ddbf1c35 100644
---- a/Configurations/windows-makefile.tmpl
-+++ b/Configurations/windows-makefile.tmpl
-@@ -164,8 +164,8 @@ libdir={- file_name_is_absolute($libdir)
- 
- ##### User defined commands and flags ################################
- 
--CC={- $config{CC} -}
--CPP={- $config{CPP} -}
-+CC="{- $config{CC} -}"
-+CPP="{- $config{CPP} -}"
- CPPFLAGS={- our $cppflags1 = join(" ",
-                                   (map { "-D".$_} @{$config{CPPDEFINES}}),
-                                   (map { " /I ".$_} @{$config{CPPINCLUDES}}),
-diff --git a/Configure b/Configure
-index 5a699836f3..859b9f4ad9 100755
---- a/Configure
-+++ b/Configure
-@@ -63,6 +63,7 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
- # zlib-dynamic  Like "zlib", but the zlib library is expected to be a shared
- #               library and will be loaded in run-time by the OpenSSL library.
- # sctp          include SCTP support
-+# no-uplink     Don't build support for UPLINK interface.
- # enable-weak-ssl-ciphers
- #               Enable weak ciphers that are disabled by default.
- # 386           generate 80386 code in assembly modules
-@@ -430,6 +431,7 @@ my @disablables = (
-     "ubsan",
-     "ui-console",
-     "unit-test",
-+    "uplink",
-     "whirlpool",
-     "weak-ssl-ciphers",
-     "zlib",
-@@ -1135,6 +1135,8 @@ foreach my $feature (@{$target{enable}}) {
-         delete $disabled{$feature};
-     }
- }
-+# If uplink_arch isn't defined, disable uplink
-+$disabled{uplink} = 'no uplink_arch' unless (defined $target{uplink_arch});
- disable();                      # Run a cascade now
- 
- $target{CXXFLAGS}//=$target{CFLAGS} if $target{CXX};
-diff --git a/INSTALL b/INSTALL
-index 2119cbae9e..51a7cd2f0b 100644
---- a/INSTALL
-+++ b/INSTALL
-@@ -544,6 +544,9 @@
-                    Enable additional unit test APIs. This should not typically
-                    be used in production deployments.
- 
-+  no-uplink
-+                   Don't build support for UPLINK interface.
-+
-   enable-weak-ssl-ciphers
-                    Build support for SSL/TLS ciphers that are considered "weak"
-                    (e.g. RC4 based ciphersuites).
-diff --git a/NOTES.WIN b/NOTES.WIN
-index b1cb542d09..7b8ceadf72 100644
---- a/NOTES.WIN
-+++ b/NOTES.WIN
-@@ -83,6 +83,18 @@
-  is, of course, to choose a different set of directories by using
-  --prefix and --openssldir when configuring.
- 
-+
-+ Special notes for Universal Windows Platform builds, a.k.a. VC-*-UWP
-+ --------------------------------------------------------------------
-+
-+ - UWP targets only support building the static and dynamic libraries.
-+
-+ - The "no-uplink" must be given in the "Configure" script.
-+
-+ - You should define the platform type to "uwp" and the target arch via
-+   "vcvarsall.bat" before you compile. For example, if you want to build
-+   "arm64" builds, you should type "vcvarsall.bat x86_arm64 uwp".
-+
-  mingw and mingw64
-  =================
- 
 diff --git a/cmake/openssl-config.cmake b/cmake/openssl-config.cmake
 new file mode 100644
-index 0000000000..6ad219072f
+index 0000000000..6dfa30c04e
 --- /dev/null
 +++ b/cmake/openssl-config.cmake
 @@ -0,0 +1,3 @@
 +# include(${CMAKE_CURRENT_LIST_DIR}/openssl.cmake)
 +include(${CMAKE_CURRENT_LIST_DIR}/crypto.cmake)
 +include(${CMAKE_CURRENT_LIST_DIR}/ssl.cmake)
-\ No newline at end of file
-diff --git a/ms/uplink-x86_64.pl b/ms/uplink-x86_64.pl
-index 1f244504cd..713e4ea8e3 100755
---- a/ms/uplink-x86_64.pl
-+++ b/ms/uplink-x86_64.pl
-@@ -8,7 +8,7 @@
- 
- $output=pop;
- $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
--open OUT,"| \"$^X\" \"${dir}../crypto/perlasm/x86_64-xlate.pl\" \"$output\"";
-+open OUT,"| \"$^X\" \"${dir}/../crypto/perlasm/x86_64-xlate.pl\" \"$output\"";
- *STDOUT=*OUT;
- push(@INC,"${dir}.");
- 

--- a/patches/sqlite.diff
+++ b/patches/sqlite.diff
@@ -3,7 +3,7 @@
 @@ -0,0 +1,84 @@
 +cmake_minimum_required(VERSION 3.2)
 +
-+project(sqlite3 VERSION 3.13.0 LANGUAGES C)
++project(sqlite3 VERSION 3.50.3 LANGUAGES C)
 +
 +if(MSVC)
 +  set(CMAKE_DEBUG_POSTFIX "d")

--- a/patches/xz.diff
+++ b/patches/xz.diff
@@ -6,7 +6,7 @@ index 0000000..4c6e540
 @@ -0,0 +1,240 @@
 +cmake_minimum_required(VERSION 3.2)
 +
-+project(xz VERSION 5.2.4 LANGUAGES C)
++project(xz VERSION 5.2.5 LANGUAGES C)
 +
 +if(MSVC)
 +  set(CMAKE_DEBUG_POSTFIX "d")

--- a/patches/zlib.diff
+++ b/patches/zlib.diff
@@ -1,0 +1,90 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 15ceebe..f459b85 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -150,9 +150,9 @@ if(MINGW)
+ endif(MINGW)
+ 
+ add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+-target_include_directories(zlib PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
++# target_include_directories(zlib PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+ add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+-target_include_directories(zlibstatic PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
++# target_include_directories(zlibstatic PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+ set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
+ set_target_properties(zlib PROPERTIES SOVERSION 1)
+ 
+@@ -173,16 +173,46 @@ if(UNIX)
+    if(NOT APPLE AND NOT(CMAKE_SYSTEM_NAME STREQUAL AIX))
+      set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
+    endif()
+-elseif(BUILD_SHARED_LIBS AND WIN32)
++# elseif(BUILD_SHARED_LIBS AND WIN32)
+     # Creates zlib1.dll when building shared library version
+-    set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
++    # set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
+ endif()
+ 
+ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
+-    install(TARGETS zlib zlibstatic
+-        RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+-        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+-        LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
++    install(TARGETS zlib zlibstatic EXPORT zlib
++        RUNTIME DESTINATION bin
++        ARCHIVE DESTINATION lib
++        LIBRARY DESTINATION lib
++        INCLUDES DESTINATION include
++    )
++    install(EXPORT zlib
++        NAMESPACE zlib::
++        DESTINATION lib/cmake/zlib
++    )
++    if(MSVC)
++        install(
++            FILES $<TARGET_PDB_FILE:zlib>
++            COMPONENT Runtime
++            DESTINATION lib
++        )
++        install(FILES
++            ${CMAKE_BINARY_DIR}/RelWithDebInfo/zlibstatic.pdb
++            DESTINATION lib
++            CONFIGURATIONS RelWithDebInfo
++        )
++        install(FILES
++            ${CMAKE_BINARY_DIR}/Debug/zlibstaticd.pdb
++            DESTINATION lib
++            CONFIGURATIONS Debug
++        )
++    endif()
++
++    install(FILES
++        cmake/${PROJECT_NAME}-config.cmake
++        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
++        DESTINATION
++            lib/cmake/${PROJECT_NAME}
++    )
+ endif()
+ if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL )
+     install(FILES ${ZLIB_PUBLIC_HDRS} DESTINATION "${INSTALL_INC_DIR}")
+@@ -194,6 +224,13 @@ if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
+     install(FILES ${ZLIB_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")
+ endif()
+ 
++include(CMakePackageConfigHelpers)
++write_basic_package_version_file(
++    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
++    VERSION ${VERSION}
++    COMPATIBILITY AnyNewerVersion
++)
++
+ #============================================================================
+ # Example binaries
+ #============================================================================
+diff --git a/cmake/zlib-config.cmake b/cmake/zlib-config.cmake
+new file mode 100644
+index 0000000..f171680
+--- /dev/null
++++ b/cmake/zlib-config.cmake
+@@ -0,0 +1 @@
++include(${CMAKE_CURRENT_LIST_DIR}/zlib.cmake)


### PR DESCRIPTION
- Bump Python to 3.13.5
- Bump libexpat to 2.7.1
- Bump OpenSSL to 3.0.17
- Bump MariaDB Connector/C to 3.3.15
- Bump Zlib to 1.3.1
- Bump xz to 5.2.5 (newer versions exist but keep in sync with what Python use)
- Bump SQLite to 3500300 (3.50.3)

