### PR TITLE
Bump libmicrohttpd to v0.9.77

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,14 +424,16 @@ ExternalProject_Add(libbdplus
 add_dependency_project_package(libbdplus 0.1.2)
 
 ExternalProject_Add(libmicrohttpd
-    GIT_REPOSITORY https://github.com/Paxxi/libmicrohttpd
-    GIT_TAG 3ef6844ec76d867a2188a345938643653f837209
-    GIT_SHALLOW ON
+    DOWNLOAD_NAME libmicrohttpd-0.9.77.tar.gz
+    DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
+    URL https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.77.tar.gz
+    URL_HASH SHA256=9e7023a151120060d2806a6ea4c13ca9933ece4eacfc5c9464d20edddb76b0a0
+    PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
 )
-add_dependency_project_package(libmicrohttpd 0.9.69)
+add_dependency_project_package(libmicrohttpd 0.9.77)
 
 ExternalProject_Add(libxml2
     DEPENDS libiconv

--- a/patches/libmicrohttpd.diff
+++ b/patches/libmicrohttpd.diff
@@ -1,0 +1,172 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 00000000..b1abaa3a
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,127 @@
++cmake_minimum_required(VERSION 3.15)
++
++project(libmicrohttpd LANGUAGES C VERSION 0.9.77)
++
++if(MSVC)
++  set(CMAKE_DEBUG_POSTFIX "_d")
++endif()
++
++set(libmicrohttpd_headers
++  src/include/autoinit_funcs.h
++  src/include/microhttpd.h
++  src/include/mhd_options.h
++  src/include/platform.h
++  src/microhttpd/connection.h
++  src/microhttpd/internal.h
++  src/microhttpd/md5.h
++  src/microhttpd/sha256.h
++  src/microhttpd/memorypool.h
++  src/microhttpd/mhd_assert.h
++  src/microhttpd/mhd_align.h
++  src/microhttpd/mhd_bithelpers.h
++  src/microhttpd/mhd_byteorder.h
++  src/microhttpd/mhd_limits.h
++  src/microhttpd/mhd_mono_clock.h
++  src/microhttpd/response.h
++  src/microhttpd/tsearch.h
++  src/microhttpd/sysfdsetsize.h
++  src/microhttpd/mhd_str.h
++  src/microhttpd/mhd_threads.h
++  src/microhttpd/mhd_locks.h
++  src/microhttpd/mhd_send.h
++  src/microhttpd/mhd_sockets.h
++  src/microhttpd/mhd_itc.h
++  src/microhttpd/mhd_itc_types.h
++  src/microhttpd/mhd_compat.h
++  w32/common/MHD_config.h
++)
++
++add_library(libmicrohttpd
++  ${libmicrohttpd_headers}
++  src/microhttpd/basicauth.c
++  src/microhttpd/connection.c
++  src/microhttpd/daemon.c
++  src/microhttpd/digestauth.c
++  src/microhttpd/internal.c
++  src/microhttpd/md5.c
++  src/microhttpd/sha256.c
++  src/microhttpd/memorypool.c
++  src/microhttpd/mhd_mono_clock.c
++  src/microhttpd/postprocessor.c
++  src/microhttpd/reason_phrase.c
++  src/microhttpd/response.c
++  src/microhttpd/tsearch.c
++  src/microhttpd/sysfdsetsize.c
++  src/microhttpd/mhd_str.c
++  src/microhttpd/mhd_threads.c
++  src/microhttpd/mhd_send.c
++  src/microhttpd/mhd_sockets.c
++  src/microhttpd/mhd_itc.c
++)
++
++target_include_directories(
++  libmicrohttpd PRIVATE
++  $<BUILD_INTERFACE:src/include;src/microhttpd;src/platform;w32/common>
++  INTERFACE
++  $<INSTALL_INTERFACE:include>
++)
++
++target_compile_definitions(libmicrohttpd
++  PRIVATE
++    _CRT_SECURE_NO_WARNINGS
++    _CRT_NONSTDC_NO_WARNINGS
++    MHD_W32LIB
++    _WIN32_WINNT=0x0A00
++)
++
++if(WINDOWS_STORE)
++  target_compile_definitions(libmicrohttpd
++    PRIVATE
++      MS_APP
++  )
++endif()
++
++target_link_options(libmicrohttpd
++  PRIVATE
++    /debug:full
++)
++
++if(MSVC)
++  set_target_properties(libmicrohttpd PROPERTIES COMPILE_PDB_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR} COMPILE_PDB_NAME libmicrohttpd COMPILE_PDB_NAME_DEBUG libmicrohttpd_d)
++  install(FILES ${PROJECT_BINARY_DIR}/RelWithDebInfo/libmicrohttpd.pdb DESTINATION lib CONFIGURATIONS RelWithDebInfo)
++  install(FILES ${PROJECT_BINARY_DIR}/Debug/libmicrohttpd_d.pdb DESTINATION lib CONFIGURATIONS Debug)
++endif()
++
++include(CMakePackageConfigHelpers)
++write_basic_package_version_file(
++  ${CMAKE_CURRENT_BINARY_DIR}/libmicrohttpd-config-version.cmake
++  VERSION ${libmicrohttpd_VERSION}
++  COMPATIBILITY AnyNewerVersion
++)
++
++install(TARGETS libmicrohttpd EXPORT libmicrohttpd
++  RUNTIME DESTINATION bin
++  ARCHIVE DESTINATION lib
++  LIBRARY DESTINATION lib
++)
++
++install(FILES
++  src/include/microhttpd.h
++  DESTINATION include)
++
++install(EXPORT libmicrohttpd
++  FILE
++    libmicrohttpd.cmake
++  NAMESPACE
++    libmicrohttpd::
++  DESTINATION
++    lib/cmake/libmicrohttpd
++)
++
++install(
++  FILES
++    cmake/libmicrohttpd-config.cmake
++    ${CMAKE_CURRENT_BINARY_DIR}/libmicrohttpd-config-version.cmake
++  DESTINATION
++    lib/cmake/libmicrohttpd
++)
+diff --git a/cmake/libmicrohttpd-config.cmake b/cmake/libmicrohttpd-config.cmake
+new file mode 100644
+index 00000000..125e9223
+--- /dev/null
++++ b/cmake/libmicrohttpd-config.cmake
+@@ -0,0 +1 @@
++include(${CMAKE_CURRENT_LIST_DIR}/libmicrohttpd.cmake)
+diff --git a/src/microhttpd/memorypool.c b/src/microhttpd/memorypool.c
+index 8d80f888..2a888908 100644
+--- a/src/microhttpd/memorypool.c
++++ b/src/microhttpd/memorypool.c
+@@ -296,7 +296,11 @@ MHD_pool_create (size_t max)
+                          -1,
+                          0);
+ #elif defined(_WIN32)
++#ifdef MS_APP
++    pool->memory = VirtualAllocFromApp (NULL,
++#else
+     pool->memory = VirtualAlloc (NULL,
++#endif
+                                  alloc_size,
+                                  MEM_COMMIT | MEM_RESERVE,
+                                  PAGE_READWRITE);
+diff --git a/src/microhttpd/mhd_sockets.c b/src/microhttpd/mhd_sockets.c
+index 2e49652c..5e724848 100644
+--- a/src/microhttpd/mhd_sockets.c
++++ b/src/microhttpd/mhd_sockets.c
+@@ -459,9 +459,11 @@ MHD_socket_noninheritable_ (MHD_socket sock)
+                     flags | FD_CLOEXEC)) )
+     return 0;
+ #elif defined(MHD_WINSOCK_SOCKETS)
++#ifndef MS_APP
+   if (! SetHandleInformation ((HANDLE) sock,
+                               HANDLE_FLAG_INHERIT,
+                               0))
++#endif
+     return 0;
+ #endif /* MHD_WINSOCK_SOCKETS */
+   return ! 0;


### PR DESCRIPTION
Bump libmicrohttpd to v0.9.77

Changed build method from git repo to download source because currently build is broken due bad link to submodule "build-common" here https://github.com/Paxxi/libmicrohttpd/tree/kodi/contrib

Also updated to v0.9.77 (the same version used on other platforms).