### PR TITLE
Bump libxml2 to 2.15.1 / libplist to 2.7.0

### DIFF
--- a/BuildAllPlatforms.ps1
+++ b/BuildAllPlatforms.ps1
@@ -35,7 +35,6 @@ Param(
     'libudfread',
     'libwebp',
     'libxml2',
-    'libxslt',
     'miniwdk',
     'openssl',
     'python',

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,44 +418,34 @@ ExternalProject_Add(libbdplus
 add_dependency_project_package(libbdplus 0.1.2)
 
 ExternalProject_Add(libxml2
-    DEPENDS libiconv
-    GIT_REPOSITORY https://github.com/Paxxi/libxml2
-    GIT_TAG c9e6dae59f576f0e40dbef5d52f11b3de00e8a7d
-    GIT_SHALLOW ON
+    DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
+    URL https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.1.tar.xz
+    URL_HASH SHA256=c008bac08fd5c7b4a87f7b8a71f283fa581d80d80ff8d2efd3b26224c39bc54c
+    PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
-        -DCMAKE_PREFIX_PATH:PATH=${PREFIX}%3B%3B${PREFIX}/libiconv
         -DBUILD_SHARED_LIBS:BOOL=ON
+        -DLIBXML2_WITH_DEBUG:BOOL=OFF
+        -DLIBXML2_WITH_ICONV:BOOL=OFF
+        -DLIBXML2_WITH_MODULES:BOOL=OFF
+        -DLIBXML2_WITH_PROGRAMS:BOOL=OFF
+        -DLIBXML2_WITH_TESTS:BOOL=OFF
 )
-add_dependency_project_package(libxml2 2.9.9)
-
-ExternalProject_Add(libxslt
-    DEPENDS libiconv libxml2 uwp_compat
-    GIT_REPOSITORY https://github.com/Paxxi/libxslt
-    GIT_TAG f63869008f803398f86697031201f83812d65732
-    GIT_SHALLOW ON
-    CMAKE_ARGS
-        ${ADDITIONAL_ARGS}
-        -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
-        -DCMAKE_PREFIX_PATH:PATH=${PREFIX}%3B%3B${PREFIX}/libiconv%3B%3B${PREFIX}/libxml2%3B%3B${PREFIX}/uwp_compat
-        -DBUILD_SHARED_LIBS:BOOL=ON
-)
-add_dependency_project_package(libxslt 1.1.34)
+add_dependency_project_package(libxml2 2.15.1)
 
 if(NOT WINDOWS_STORE)
 ExternalProject_Add(libplist
-    DEPENDS libiconv libxml2
-    GIT_REPOSITORY https://github.com/Paxxi/libplist
-    GIT_TAG 80d48b2bbec8dfb0c81db2074dedfa5b92fb2593
-    GIT_SHALLOW ON
+    DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads
+    URL https://github.com/libimobiledevice/libplist/releases/download/2.7.0/libplist-2.7.0.tar.bz2
+    URL_HASH SHA256=7ac42301e896b1ebe3c654634780c82baa7cb70df8554e683ff89f7c2643eb8b
+    PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_SOURCE_DIR}/patches/$(TargetName).diff
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
-        -DCMAKE_PREFIX_PATH:PATH=${PREFIX}%3B%3B${PREFIX}/libiconv%3B%3B${PREFIX}/libxml2
         -DBUILD_SHARED_LIBS:BOOL=ON
 )
-add_dependency_project_package(libplist 2.1.0)
+add_dependency_project_package(libplist 2.7.0)
 endif()
 
 ExternalProject_Add(giflib
@@ -676,7 +666,6 @@ add_custom_target(DependenciesRequired
         libudfread
         libwebp
         libxml2
-        libxslt
         #miniwdk # WDK is not installed on github hosted runners
         openssl
         python

--- a/patches/libbluray.diff
+++ b/patches/libbluray.diff
@@ -179,7 +179,7 @@
 +endif(NOT WINDOWS_STORE)
 +
 +add_library(libbluray SHARED ${SRCS})
-+target_link_libraries(libbluray PRIVATE freetype::freetype iconv::iconv libxml2::libxml2 libudfread::libudfread)
++target_link_libraries(libbluray PRIVATE freetype::freetype iconv::iconv LibXml2::LibXml2 libudfread::libudfread)
 +set_target_properties(libbluray
 +  PROPERTIES
 +    LINK_FLAGS "/DEF:\"libbluray.def\""

--- a/patches/libplist.diff
+++ b/patches/libplist.diff
@@ -1,0 +1,151 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..7450056
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,138 @@
++cmake_minimum_required(VERSION 3.15)
++
++project(libplist VERSION 2.7.0 LANGUAGES C CXX)
++
++if(MSVC)
++  set(CMAKE_DEBUG_POSTFIX "d")
++endif()
++
++add_library(libcnary STATIC
++  libcnary/include/node.h
++  libcnary/include/node_list.h
++  libcnary/include/object.h
++  libcnary/node.c
++  libcnary/node_list.c
++)
++
++target_include_directories(libcnary
++  PRIVATE
++  $<BUILD_INTERFACE:libcnary/;libcnary/include>
++  PUBLIC
++  $<INSTALL_INTERFACE:libcnary/include>
++  INTERFACE
++  $<INSTALL_INTERFACE:libcnary/include>
++)
++
++add_library(libplist
++  include/plist/Array.h
++  include/plist/Boolean.h
++  include/plist/Data.h
++  include/plist/Date.h
++  include/plist/Dictionary.h
++  include/plist/Integer.h
++  include/plist/Key.h
++  include/plist/Node.h
++  include/plist/plist.h
++  include/plist/plist++.h
++  include/plist/Real.h
++  include/plist/String.h
++  include/plist/Structure.h
++  include/plist/Uid.h
++  src/Array.cpp
++  src/base64.c
++  src/base64.h
++  src/Boolean.cpp
++  src/bplist.c
++  src/bytearray.c
++  src/bytearray.h
++  src/Data.cpp
++  src/Date.cpp
++  src/Dictionary.cpp
++  src/hashtable.c
++  src/hashtable.h
++  src/Integer.cpp
++  src/jplist.c
++  src/jsmn.c
++  src/jsmn.h
++  src/Key.cpp
++  src/Node.cpp
++  src/oplist.c
++  src/out-default.c
++  src/out-limd.c
++  src/out-plutil.c
++  src/plist.c
++  src/plist.h
++  src/ptrarray.c
++  src/ptrarray.h
++  src/Real.cpp
++  src/strbuf.h
++  src/String.cpp
++  src/Structure.cpp
++  src/time64_limits.h
++  src/time64.c
++  src/time64.h
++  src/Uid.cpp
++  src/xplist.c
++)
++
++target_include_directories(
++  libplist PRIVATE
++  $<BUILD_INTERFACE:include/;src/;libcnary/include/>
++  INTERFACE
++  $<INSTALL_INTERFACE:include/plist>
++)
++
++target_compile_definitions(libplist PRIVATE
++  _CRT_SECURE_NO_WARNINGS
++  PACKAGE_VERSION="${CMAKE_PROJECT_VERSION}"
++)
++
++if(NOT BUILD_SHARED_LIBS)
++  target_compile_definitions(libplist PRIVATE LIBPLIST_STATIC)
++endif()
++
++target_compile_options(libplist PRIVATE /MP /sdl-)
++
++target_link_libraries(libplist PRIVATE libcnary)
++
++include(CMakePackageConfigHelpers)
++write_basic_package_version_file(
++  ${CMAKE_CURRENT_BINARY_DIR}/libplist-config-version.cmake
++  VERSION ${CMAKE_PROJECT_VERSION}
++  COMPATIBILITY AnyNewerVersion
++)
++
++install(TARGETS libplist EXPORT libplist
++  RUNTIME DESTINATION bin
++  ARCHIVE DESTINATION lib
++  LIBRARY DESTINATION lib
++)
++
++install(DIRECTORY
++  include/plist
++  DESTINATION include
++)
++
++install(EXPORT libplist
++  FILE
++    libplist.cmake
++  NAMESPACE
++    libplist::
++  DESTINATION
++    lib/cmake/libplist
++)
++
++install(
++  FILES
++    cmake/libplist-config.cmake
++    ${CMAKE_CURRENT_BINARY_DIR}/libplist-config-version.cmake
++  DESTINATION
++    lib/cmake/libplist
++)
++
++if(BUILD_SHARED_LIBS)
++  install(FILES
++    $<TARGET_PDB_FILE:libplist>
++    DESTINATION lib
++  )
++endif()
+diff --git a/cmake/libplist-config.cmake b/cmake/libplist-config.cmake
+new file mode 100644
+index 0000000..2249c1d
+--- /dev/null
++++ b/cmake/libplist-config.cmake
+@@ -0,0 +1 @@
++include(${CMAKE_CURRENT_LIST_DIR}/libplist.cmake)

--- a/patches/libxml2.diff
+++ b/patches/libxml2.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 116c77dd..67d4b059 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -403,6 +403,8 @@ set_target_properties(
+ )
+ 
+ if(MSVC)
++    target_compile_definitions(LibXml2 PRIVATE _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES)
++    target_compile_options(LibXml2 PRIVATE /MP /sdl-)
+     if(BUILD_SHARED_LIBS)
+         set_target_properties(
+             LibXml2


### PR DESCRIPTION
- Bump libxml2 to 2.15.1
- Bump libplist to 2.7.0

NOTES:
- libxslt is removed due is build in main Kodi repo.
- ~libbluray is disabled~ because libxml2 cmake namespace has changed (anyway libbluray will be build in main kodi repo).


