### PR TITLE
Bump Python to 3.14.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,14 +475,14 @@ add_dependency_project_package(zstd 1.5.7)
 ExternalProject_Add(python
     DEPENDS bzip2 openssl sqlite zlib expat libffi xz zstd
     GIT_REPOSITORY https://github.com/thexai/cpython
-    GIT_TAG 91b1f7f5a72a25f7974ce3999ef8d45cc43c35e4
+    GIT_TAG 44c9b4bf99579f5afa1800fd0b21e0c031b54a38
     GIT_SHALLOW ON
     CMAKE_ARGS
         ${ADDITIONAL_ARGS}
         -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX}
         -DCMAKE_PREFIX_PATH:PATH=${PREFIX}%3B%3B${PREFIX}/bzip2%3B%3B${PREFIX}/openssl%3B%3B${PREFIX}/sqlite%3B%3B${PREFIX}/zlib%3B%3B${PREFIX}/libffi%3B%3B${PREFIX}/xz%3B%3B${PREFIX}/expat%3B%3B${PREFIX}/zstd
 )
-add_dependency_project_package(python 3.14.6)
+add_dependency_project_package(python 3.14.7)
 
 ExternalProject_Add(libjpeg-turbo
     DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/downloads


### PR DESCRIPTION
Besides of bump itself, the Kodi patches has improved A LOT, related to current upstream Kodi patches work and feedback from Python devs. 

Several bugs have been fixed (some present from Python 3.8 days), performance has been improved, and patches has been simplified...